### PR TITLE
Do not make the stimuli clickable

### DIFF
--- a/src/features/read/components/Question.tsx
+++ b/src/features/read/components/Question.tsx
@@ -91,16 +91,15 @@ function Stimulus({ decorate, disabled, onClick, stimulus }: StimulusProps) {
         src={stimulus.fields.image.fields.file.url}
         style={{ maxWidth: "100%", height: "auto" }}
       />
-      {!disabled && (
-        <Button
-          disabled={disabled}
-          variant="primary"
-          size="lg"
-          onClick={() => onClick(stimulus.sys.id)}
-        >
-          Select
-        </Button>
-      )}
+      <Button
+        disabled={disabled}
+        variant="primary"
+        size="lg"
+        onClick={() => onClick(stimulus.sys.id)}
+        style={{ visibility: disabled ? "hidden" : "visible" }}
+      >
+        Select
+      </Button>
       {decorate === "CORRECT" && (
         <p className={`text-success ${styles.feedback}`}>Nice work!</p>
       )}

--- a/src/features/read/components/Question.tsx
+++ b/src/features/read/components/Question.tsx
@@ -76,32 +76,31 @@ interface OnStimulusClick {
 
 function Stimulus({ decorate, disabled, onClick, stimulus }: StimulusProps) {
   const cx = cn(
-    "d-flex flex-column justify-content-between w-50 h-100",
+    `d-flex flex-column justify-content-between w-50 h-100`,
     {
       "border border-success": decorate === "CORRECT",
       "border border-danger": decorate === "WRONG",
     },
-    {
-      [styles.stimulus]: disabled === false,
-      [styles.disabledStimulus]: disabled === true,
-    }
+    { [styles.stimulus]: true }
   );
 
   return (
-    <div
-      className={cx}
-      aria-disabled={disabled}
-      onClick={() => onClick(stimulus.sys.id)}
-      role="button"
-    >
+    <div className={cx}>
       <img
         alt={stimulus.fields.image.fields.description}
         src={stimulus.fields.image.fields.file.url}
         style={{ maxWidth: "100%", height: "auto" }}
       />
-      <Button disabled={disabled} variant="link" size="lg">
-        Pick me
-      </Button>
+      {!disabled && (
+        <Button
+          disabled={disabled}
+          variant="primary"
+          size="lg"
+          onClick={() => onClick(stimulus.sys.id)}
+        >
+          Select
+        </Button>
+      )}
       {decorate === "CORRECT" && (
         <p className={`text-success ${styles.feedback}`}>Nice work!</p>
       )}

--- a/src/features/read/components/question.module.css
+++ b/src/features/read/components/question.module.css
@@ -1,23 +1,8 @@
-.stimulus:hover {
-  box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.15);
-}
-
-.stimulus:active {
-  box-shadow: none;
-  opacity: 0.5;
-}
-
-.disabledStimulus {
-  cursor: not-allowed;
-}
-
-.stimulus,
-.disabledStimulus {
+.stimulus {
   position: relative;
 }
 
-.stimulus + .stimulus,
-.disabledStimulus + .disabledStimulus {
+.stimulus + .stimulus {
   /*
    * I should probably consider leveraging bootstrap's Rows and Cols instead 
    * That way, if I need to wrap on narrow screens, I get stacking with correct spacing


### PR DESCRIPTION
Children will often touch the stimuli to count the number of shapes. This avoids accidental selections.